### PR TITLE
Add config management API

### DIFF
--- a/src/main/java/tc/oc/bingo/card/RewardManager.java
+++ b/src/main/java/tc/oc/bingo/card/RewardManager.java
@@ -3,6 +3,7 @@ package tc.oc.bingo.card;
 import static net.kyori.adventure.text.Component.text;
 
 import java.util.BitSet;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -50,7 +51,7 @@ public class RewardManager implements Listener {
     Bukkit.getServer().getPluginManager().registerEvents(this, bingo);
   }
 
-  public void rewardPlayers(String objectiveSlug, List<Player> players) {
+  public void rewardPlayers(String objectiveSlug, Collection<Player> players) {
     List<ProgressItem> filteredCardItems =
         players.stream()
             .map(player -> tryComplete(player, objectiveSlug))

--- a/src/main/java/tc/oc/bingo/config/ConfigHandler.java
+++ b/src/main/java/tc/oc/bingo/config/ConfigHandler.java
@@ -1,0 +1,64 @@
+package tc.oc.bingo.config;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Supplier;
+import lombok.extern.java.Log;
+import org.bukkit.configuration.ConfigurationSection;
+
+@Log
+public class ConfigHandler {
+
+  private final List<ConfigSetting<?>> configs = new ArrayList<>();
+
+  private <T> ConfigSetting<T> register(ConfigSetting<T> setting) {
+    configs.add(setting);
+    return setting;
+  }
+
+  public void reload(ConfigurationSection section) {
+    Set<String> unused = new HashSet<>(section.getKeys(false));
+    List<String> undefined = new ArrayList<>();
+    configs.forEach(
+        config -> {
+          config.read(section);
+          String key = config.getKey();
+          if (key != null && !unused.remove(key)) undefined.add(key);
+        });
+
+    if (!unused.isEmpty() || !undefined.isEmpty()) {
+      log.warning(
+          String.format(
+              "Config misuses in section '%s': Unused keys %s, Undefined keys: %s",
+              section.getName(), unused, undefined));
+    }
+  }
+
+  public interface Extensions {
+
+    ConfigHandler getConfig();
+
+    default Supplier<Integer> useConfig(String key, int defaultValue) {
+      return getConfig().register(new ConfigSetting<>(key, defaultValue, ConfigReader.INT_READER));
+    }
+
+    default Supplier<Boolean> useConfig(String key, boolean defaultValue) {
+      return getConfig().register(new ConfigSetting<>(key, defaultValue, ConfigReader.BOOL_READER));
+    }
+
+    default Supplier<Double> useConfig(String key, double defaultValue) {
+      return getConfig()
+          .register(new ConfigSetting<>(key, defaultValue, ConfigReader.DOUBLE_READER));
+    }
+
+    default <T> Supplier<T> useConfig(String key, T def, ConfigReader<T> reader) {
+      return getConfig().register(new ConfigSetting<>(key, def, reader));
+    }
+
+    default <T> Supplier<T> useComputedConfig(Supplier<T> value) {
+      return getConfig().register(new ConfigSetting<>(null, value.get(), (f, k, d) -> value.get()));
+    }
+  }
+}

--- a/src/main/java/tc/oc/bingo/config/ConfigReader.java
+++ b/src/main/java/tc/oc/bingo/config/ConfigReader.java
@@ -1,0 +1,12 @@
+package tc.oc.bingo.config;
+
+import org.bukkit.configuration.ConfigurationSection;
+
+@FunctionalInterface
+public interface ConfigReader<T> {
+  ConfigReader<Integer> INT_READER = ConfigurationSection::getInt;
+  ConfigReader<Double> DOUBLE_READER = ConfigurationSection::getDouble;
+  ConfigReader<Boolean> BOOL_READER = ConfigurationSection::getBoolean;
+
+  T read(ConfigurationSection section, String key, T defaultValue);
+}

--- a/src/main/java/tc/oc/bingo/config/ConfigSetting.java
+++ b/src/main/java/tc/oc/bingo/config/ConfigSetting.java
@@ -1,0 +1,28 @@
+package tc.oc.bingo.config;
+
+import java.util.function.Supplier;
+import lombok.Data;
+import org.bukkit.configuration.ConfigurationSection;
+
+@Data
+class ConfigSetting<T> implements Supplier<T> {
+  protected final String key;
+  private final T defaultValue;
+  private final ConfigReader<T> reader;
+  private T value;
+
+  ConfigSetting(String key, T defaultValue, ConfigReader<T> reader) {
+    this.key = key;
+    this.value = this.defaultValue = defaultValue;
+    this.reader = reader;
+  }
+
+  public void read(ConfigurationSection section) {
+    value = reader.read(section, key, defaultValue);
+  }
+
+  @Override
+  public T get() {
+    return value;
+  }
+}

--- a/src/main/java/tc/oc/bingo/objectives/AnvilKillerObjective.java
+++ b/src/main/java/tc/oc/bingo/objectives/AnvilKillerObjective.java
@@ -1,7 +1,7 @@
 package tc.oc.bingo.objectives;
 
+import java.util.function.Supplier;
 import org.bukkit.Material;
-import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.FallingBlock;
 import org.bukkit.entity.Player;
@@ -19,14 +19,9 @@ import tc.oc.pgm.tracker.info.BlockInfo;
 @Tracker("anvil-killer")
 public class AnvilKillerObjective extends ObjectiveTracker {
 
-  boolean requiresKill = false;
+  private final Supplier<Boolean> REQUIRES_KILL = useConfig("requires-kill", false);
 
   private TrackerMatchModule tracker;
-
-  @Override
-  public void setConfig(ConfigurationSection config) {
-    requiresKill = config.getBoolean("requires-kill", false);
-  }
 
   @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
   public void onMatchLoad(MatchLoadEvent event) {
@@ -35,7 +30,7 @@ public class AnvilKillerObjective extends ObjectiveTracker {
 
   @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
   public void onPlayerDamage(EntityDamageByEntityEvent event) {
-    if (requiresKill || tracker == null) return;
+    if (REQUIRES_KILL.get() || tracker == null) return;
 
     if (!(event.getEntity() instanceof Player)) return;
 

--- a/src/main/java/tc/oc/bingo/objectives/ArmourSharedObjective.java
+++ b/src/main/java/tc/oc/bingo/objectives/ArmourSharedObjective.java
@@ -17,8 +17,8 @@ import tc.oc.pgm.api.player.MatchPlayerState;
 @Tracker("armour-shared")
 public class ArmourSharedObjective extends ObjectiveTracker {
 
-  public Map<Integer, MatchPlayerState> itemThrowers = new HashMap<>();
-  public Map<UUID, boolean[]> equippedPieces = useState(Scope.LIFE);
+  private final Map<Integer, MatchPlayerState> itemThrowers = new HashMap<>();
+  private final Map<UUID, boolean[]> equippedPieces = useState(Scope.LIFE);
 
   @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
   public void onMatchLoad(MatchLoadEvent event) {

--- a/src/main/java/tc/oc/bingo/objectives/BigFallObjective.java
+++ b/src/main/java/tc/oc/bingo/objectives/BigFallObjective.java
@@ -1,6 +1,6 @@
 package tc.oc.bingo.objectives;
 
-import org.bukkit.configuration.ConfigurationSection;
+import java.util.function.Supplier;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import tc.oc.pgm.api.player.MatchPlayer;
@@ -11,12 +11,7 @@ import tc.oc.pgm.tracker.Trackers;
 @Tracker("big-fall")
 public class BigFallObjective extends ObjectiveTracker {
 
-  private int minFallHeight = 100;
-
-  @Override
-  public void setConfig(ConfigurationSection config) {
-    minFallHeight = config.getInt("min-fall-height", 100);
-  }
+  private final Supplier<Integer> MIN_FALL_HEIGHT = useConfig("min-fall-height", 100);
 
   @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
   public void onPlayerDeath(MatchPlayerDeathEvent event) {
@@ -33,7 +28,7 @@ public class BigFallObjective extends ObjectiveTracker {
             Trackers.distanceFromRanged(fallInfo, event.getVictim().getBukkit().getLocation());
 
         if (!Double.isNaN(distance)) {
-          if (distance >= minFallHeight) {
+          if (distance >= MIN_FALL_HEIGHT.get()) {
             reward(player.getBukkit());
           }
         }

--- a/src/main/java/tc/oc/bingo/objectives/CleanMatchObjective.java
+++ b/src/main/java/tc/oc/bingo/objectives/CleanMatchObjective.java
@@ -1,8 +1,8 @@
 package tc.oc.bingo.objectives;
 
 import java.util.Collection;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
-import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import tc.oc.pgm.api.match.event.MatchFinishEvent;
@@ -15,16 +15,11 @@ import tc.oc.pgm.goals.TouchableGoal;
 @Tracker("clean-match")
 public class CleanMatchObjective extends ObjectiveTracker {
 
-  private int minParticipants;
-
-  @Override
-  public void setConfig(ConfigurationSection config) {
-    minParticipants = config.getInt("min-participants", 10);
-  }
+  private final Supplier<Integer> MIN_PARTICIPANTS = useConfig("min-participants", 10);
 
   @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
   public void onMatchFinish(MatchFinishEvent event) {
-    if (event.getMatch().getParticipants().size() < minParticipants) return;
+    if (event.getMatch().getParticipants().size() < MIN_PARTICIPANTS.get()) return;
 
     Collection<Competitor> winners = event.getMatch().getWinners();
     if (winners.size() != 1) return;

--- a/src/main/java/tc/oc/bingo/objectives/EatingObjective.java
+++ b/src/main/java/tc/oc/bingo/objectives/EatingObjective.java
@@ -4,8 +4,8 @@ import java.util.EnumSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.function.Supplier;
 import org.bukkit.Material;
-import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.player.PlayerItemConsumeEvent;
@@ -13,14 +13,9 @@ import org.bukkit.event.player.PlayerItemConsumeEvent;
 @Tracker("eating")
 public class EatingObjective extends ObjectiveTracker {
 
-  public int foodsRequired = 3;
+  private final Supplier<Integer> FOODS_REQUIRED = useConfig("foods-required", 3);
 
   private final Map<UUID, Set<Material>> consumedIds = useState(Scope.LIFE);
-
-  @Override
-  public void setConfig(ConfigurationSection config) {
-    foodsRequired = config.getInt("foods-required", 3);
-  }
 
   @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
   public void onPlayerConsume(PlayerItemConsumeEvent event) {
@@ -31,7 +26,7 @@ public class EatingObjective extends ObjectiveTracker {
       Set<Material> consumedItems =
           consumedIds.computeIfAbsent(playerUUID, id -> EnumSet.noneOf(Material.class));
 
-      if (consumedItems.add(item) && consumedItems.size() >= foodsRequired)
+      if (consumedItems.add(item) && consumedItems.size() >= FOODS_REQUIRED.get())
         reward(event.getPlayer());
     }
   }

--- a/src/main/java/tc/oc/bingo/objectives/FlowerPotObjective.java
+++ b/src/main/java/tc/oc/bingo/objectives/FlowerPotObjective.java
@@ -1,8 +1,8 @@
 package tc.oc.bingo.objectives;
 
+import java.util.function.Supplier;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
-import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -15,12 +15,7 @@ import tc.oc.pgm.api.match.Match;
 public class FlowerPotObjective extends ObjectiveTracker {
 
   // Bypass the flower-only restriction, allow bush, mushroom to work
-  private boolean allowAny = false;
-
-  @Override
-  public void setConfig(ConfigurationSection config) {
-    allowAny = config.getBoolean("allow-any", false);
-  }
+  private final Supplier<Boolean> ALLOW_ANY = useConfig("allow-any", false);
 
   @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
   public void onPlayerInteract(PlayerInteractEvent event) {
@@ -30,7 +25,7 @@ public class FlowerPotObjective extends ObjectiveTracker {
     Block block = event.getClickedBlock();
     if (block.getType().equals(Material.FLOWER_POT)) {
       ItemStack itemInHand = player.getItemInHand();
-      if (allowAny || isFlower(itemInHand.getType())) {
+      if (ALLOW_ANY.get() || isFlower(itemInHand.getType())) {
         Match match = getMatch(event.getWorld());
         if (match == null) return;
         reward(event.getPlayer());

--- a/src/main/java/tc/oc/bingo/objectives/HedgehogObjective.java
+++ b/src/main/java/tc/oc/bingo/objectives/HedgehogObjective.java
@@ -1,6 +1,6 @@
 package tc.oc.bingo.objectives;
 
-import org.bukkit.configuration.ConfigurationSection;
+import java.util.function.Supplier;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -9,18 +9,13 @@ import org.bukkit.event.entity.EntityDamageByEntityEvent;
 @Tracker("hedgehog")
 public class HedgehogObjective extends ObjectiveTracker {
 
-  public int minArrows = 25;
-
-  @Override
-  public void setConfig(ConfigurationSection config) {
-    minArrows = config.getInt("min-arrows", 25);
-  }
+  private final Supplier<Integer> MIN_ARROWS = useConfig("min-arrows", 25);
 
   @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
   public void onEntityDamage(EntityDamageByEntityEvent event) {
     if (event.getEntity() instanceof Player) {
       Player actor = (Player) event.getEntity();
-      if (actor.getArrowsStuck() + 1 >= minArrows) {
+      if (actor.getArrowsStuck() + 1 >= MIN_ARROWS.get()) {
         reward(actor);
       }
     }

--- a/src/main/java/tc/oc/bingo/objectives/IcarusObjective.java
+++ b/src/main/java/tc/oc/bingo/objectives/IcarusObjective.java
@@ -1,7 +1,7 @@
 package tc.oc.bingo.objectives;
 
+import java.util.function.Supplier;
 import org.bukkit.Bukkit;
-import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.TNTPrimed;
 import org.bukkit.event.EventHandler;
@@ -16,17 +16,11 @@ import tc.oc.pgm.api.player.MatchPlayer;
 @Tracker("icarus-height")
 public class IcarusObjective extends ObjectiveTracker {
 
-  private double minVerticalVelocity = 6d;
+  private final Supplier<Double> minVerticalVelocity = useConfig("min-vertical-velocity", 6d);
   // This delay may be affected by ping, so keep configurable
-  private int delayTicks = 2;
+  private final Supplier<Integer> delayTicks = useConfig("delay-ticks", 2);
 
-  private Match match = null;
-
-  @Override
-  public void setConfig(ConfigurationSection config) {
-    minVerticalVelocity = config.getDouble("min-vertical-velocity", 6d);
-    delayTicks = config.getInt("delay-ticks", 2);
-  }
+  private Match match;
 
   @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
   public void onMatchLoad(MatchAfterLoadEvent event) {
@@ -52,11 +46,11 @@ public class IcarusObjective extends ObjectiveTracker {
                 if (matchPlayer.isDead()) return;
 
                 Vector velocity = player.getVelocity();
-                if (velocity.getY() >= minVerticalVelocity) {
+                if (velocity.getY() >= minVerticalVelocity.get()) {
                   reward(player);
                 }
               },
-              delayTicks);
+              delayTicks.get());
     }
   }
 }

--- a/src/main/java/tc/oc/bingo/objectives/KillStreakObjective.java
+++ b/src/main/java/tc/oc/bingo/objectives/KillStreakObjective.java
@@ -1,6 +1,6 @@
 package tc.oc.bingo.objectives;
 
-import org.bukkit.configuration.ConfigurationSection;
+import java.util.function.Supplier;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import tc.oc.pgm.api.match.event.MatchAfterLoadEvent;
@@ -11,13 +11,8 @@ import tc.oc.pgm.killreward.KillRewardMatchModule;
 @Tracker("kill-streak")
 public class KillStreakObjective extends ObjectiveTracker {
 
-  public int requiredStreak = 10;
-  private KillRewardMatchModule killRewardModule = null;
-
-  @Override
-  public void setConfig(ConfigurationSection config) {
-    requiredStreak = config.getInt("required-streak", 10);
-  }
+  private final Supplier<Integer> REQUIRED_STREAK = useConfig("required-streak", 10);
+  private KillRewardMatchModule killRewardModule;
 
   @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
   public void onMatchLoad(MatchAfterLoadEvent event) {
@@ -34,7 +29,7 @@ public class KillStreakObjective extends ObjectiveTracker {
     if (player == null) return;
 
     int streak = killRewardModule.getKillStreak(player.getId());
-    if (streak >= requiredStreak) {
+    if (streak >= REQUIRED_STREAK.get()) {
       reward(player.getBukkit());
     }
   }

--- a/src/main/java/tc/oc/bingo/objectives/MatchLengthObjective.java
+++ b/src/main/java/tc/oc/bingo/objectives/MatchLengthObjective.java
@@ -2,8 +2,8 @@ package tc.oc.bingo.objectives;
 
 import java.time.Duration;
 import java.util.List;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
-import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -13,21 +13,14 @@ import tc.oc.pgm.api.player.MatchPlayer;
 @Tracker("match-length")
 public class MatchLengthObjective extends ObjectiveTracker {
 
-  public int requiredMins = 60;
-
-  // TODO: make it so they have to be in a short and long match? duality of defender?
-
-  @Override
-  public void setConfig(ConfigurationSection config) {
-    requiredMins = config.getInt("required-mins", 60);
-  }
+  private final Supplier<Integer> REQUIRED_MINS = useConfig("required-mins", 60);
 
   @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
   public void onMatchFinish(MatchFinishEvent event) {
 
     Duration duration = event.getMatch().getDuration();
 
-    if (duration.toMinutes() < requiredMins) return;
+    if (duration.toMinutes() < REQUIRED_MINS.get()) return;
 
     List<Player> players =
         event.getMatch().getParticipants().stream()

--- a/src/main/java/tc/oc/bingo/objectives/ObjectiveTracker.java
+++ b/src/main/java/tc/oc/bingo/objectives/ObjectiveTracker.java
@@ -1,8 +1,8 @@
 package tc.oc.bingo.objectives;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Stream;
@@ -13,6 +13,7 @@ import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 import tc.oc.bingo.Bingo;
+import tc.oc.bingo.config.ConfigHandler;
 import tc.oc.bingo.database.BingoPlayerCard;
 import tc.oc.bingo.database.ProgressItem;
 import tc.oc.bingo.util.ManagedListener;
@@ -21,10 +22,11 @@ import tc.oc.bingo.util.StateHandler;
 
 @Data
 @Log
-public class ObjectiveTracker implements ManagedListener, PGMUtils {
+public class ObjectiveTracker implements ManagedListener, ConfigHandler.Extensions, PGMUtils {
 
   private final String objectiveSlug;
   private final StateHandler state = new StateHandler();
+  private final ConfigHandler config = new ConfigHandler();
 
   public ObjectiveTracker() {
     this.objectiveSlug = getClass().getDeclaredAnnotation(Tracker.class).value();
@@ -35,17 +37,19 @@ public class ObjectiveTracker implements ManagedListener, PGMUtils {
     return Stream.of(state);
   }
 
-  public void setConfig(ConfigurationSection config) {}
+  public final void setConfig(ConfigurationSection config) {
+    this.config.reload(config);
+  }
 
-  public void reward(List<Player> players) {
+  protected final void reward(Collection<Player> players) {
     Bingo.get().getRewards().rewardPlayers(objectiveSlug, players);
   }
 
-  public void reward(Player player) {
+  protected final void reward(Player player) {
     reward(Collections.singletonList(player));
   }
 
-  protected <T> Map<UUID, T> useState(Scope scope) {
+  protected final <T> Map<UUID, T> useState(Scope scope) {
     Map<UUID, T> result = new HashMap<>();
     state.registerState(scope, result);
     return result;

--- a/src/main/java/tc/oc/bingo/objectives/PickyVoterObjective.java
+++ b/src/main/java/tc/oc/bingo/objectives/PickyVoterObjective.java
@@ -5,9 +5,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import org.bukkit.Bukkit;
-import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -17,16 +17,10 @@ import tc.oc.pgm.rotation.vote.events.MatchPlayerVoteEvent;
 @Tracker("picky-voter")
 public class PickyVoterObjective extends ObjectiveTracker {
 
-  public Map<UUID, List<String>> playerVotes = useState(Scope.FULL_MATCH);
+  private final Supplier<Integer> MIN_MAP_VOTES = useConfig("min-map-votes", 4);
+  private final Supplier<Integer> MAX_MAP_VOTES = useConfig("max-map-votes", 4);
 
-  private int minMapVotes = 4;
-  private int maxMapVotes = 4;
-
-  @Override
-  public void setConfig(ConfigurationSection config) {
-    minMapVotes = config.getInt("min-map-votes", 4);
-    maxMapVotes = config.getInt("max-map-votes", 4);
-  }
+  private final Map<UUID, List<String>> playerVotes = useState(Scope.FULL_MATCH);
 
   @EventHandler(priority = EventPriority.MONITOR)
   public void onPlayerVote(MatchPlayerVoteEvent event) {
@@ -49,7 +43,7 @@ public class PickyVoterObjective extends ObjectiveTracker {
             .filter(
                 entry -> {
                   int voteCount = entry.getValue().size();
-                  return voteCount >= minMapVotes && voteCount <= maxMapVotes;
+                  return voteCount >= MIN_MAP_VOTES.get() && voteCount <= MAX_MAP_VOTES.get();
                 })
             .map(Map.Entry::getKey)
             .map(uuid -> Bukkit.getServer().getPlayer(uuid))

--- a/src/main/java/tc/oc/bingo/objectives/PlayerCraftObjective.java
+++ b/src/main/java/tc/oc/bingo/objectives/PlayerCraftObjective.java
@@ -1,25 +1,25 @@
 package tc.oc.bingo.objectives;
 
+import com.google.common.base.Objects;
+import java.util.function.Supplier;
 import org.bukkit.Material;
-import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.inventory.CraftItemEvent;
+import tc.oc.bingo.config.ConfigReader;
 
 @Tracker("player-craft")
 public class PlayerCraftObjective extends ObjectiveTracker {
 
-  public Material materialRequired = Material.PISTON_BASE;
+  private static final ConfigReader<Material> MATERIAL_READER =
+      (cfg, key, def) -> Objects.firstNonNull(Material.getMaterial(cfg.getString(key)), def);
 
-  @Override
-  public void setConfig(ConfigurationSection config) {
-    Material material = Material.getMaterial(config.getString("material-name", "PISTON_BASE"));
-    if (material != null) materialRequired = material;
-  }
+  private final Supplier<Material> MATERIAL_REQUIRED =
+      useConfig("material-name", Material.PISTON_BASE, MATERIAL_READER);
 
   @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
   public void onPlayerCraftEvent(CraftItemEvent event) {
-    if (event.getRecipe().getResult().getType().equals(materialRequired)) {
+    if (event.getRecipe().getResult().getType().equals(MATERIAL_REQUIRED.get())) {
       reward(event.getActor().getPlayer());
     }
   }

--- a/src/main/java/tc/oc/bingo/objectives/QuickKillsObjective.java
+++ b/src/main/java/tc/oc/bingo/objectives/QuickKillsObjective.java
@@ -4,31 +4,18 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import org.bukkit.configuration.ConfigurationSection;
+import java.util.function.Supplier;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
-import tc.oc.pgm.api.match.event.MatchLoadEvent;
 import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.api.player.event.MatchPlayerDeathEvent;
 
 @Tracker("quick-kills")
 public class QuickKillsObjective extends ObjectiveTracker {
 
-  public int killsRequired = 3;
-  public long timeThresholdSeconds = 5;
-
+  private final Supplier<Integer> KILLS_REQUIRED = useConfig("kills-required", 3);
+  private final Supplier<Integer> TIME_THRESHOLD_SEC = useConfig("time-threshold-seconds", 5);
   private final Map<UUID, List<Long>> lastKillTimes = useState(Scope.LIFE);
-
-  @Override
-  public void setConfig(ConfigurationSection config) {
-    killsRequired = config.getInt("kills-required", 3);
-    timeThresholdSeconds = config.getLong("time-threshold-seconds", 5);
-  }
-
-  @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
-  public void onMatchLoad(MatchLoadEvent event) {
-    lastKillTimes.clear();
-  }
 
   @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
   public void onPlayerKill(MatchPlayerDeathEvent event) {
@@ -39,14 +26,14 @@ public class QuickKillsObjective extends ObjectiveTracker {
 
     // Update kill count and check if the goal is reached
     int size = updateKillCount(player.getId());
-    if (size >= killsRequired) {
+    if (size >= KILLS_REQUIRED.get()) {
       reward(player.getBukkit());
     }
   }
 
   private int updateKillCount(UUID playerUUID) {
     long currentTime = System.currentTimeMillis();
-    long longestTimeAllowed = currentTime - (timeThresholdSeconds * 1000);
+    long longestTimeAllowed = currentTime - (TIME_THRESHOLD_SEC.get() * 1000L);
 
     // Get the set of timestamps for the current player
     List<Long> timestamps = lastKillTimes.computeIfAbsent(playerUUID, uuid -> new ArrayList<>());

--- a/src/main/java/tc/oc/bingo/objectives/WaterDropperObjective.java
+++ b/src/main/java/tc/oc/bingo/objectives/WaterDropperObjective.java
@@ -2,9 +2,9 @@ package tc.oc.bingo.objectives;
 
 import java.util.Map;
 import java.util.UUID;
+import java.util.function.Supplier;
 import org.bukkit.Location;
 import org.bukkit.block.Block;
-import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.entity.EntityDamageEvent;
@@ -21,16 +21,9 @@ import tc.oc.pgm.util.material.Materials;
 
 @Tracker("water-dropper")
 public class WaterDropperObjective extends ObjectiveTracker {
-
-  public Map<UUID, Vector> placedWater = useState(Scope.LIFE);
-
-  private int minFallHeight = 100;
-  private TrackerMatchModule tracker = null;
-
-  @Override
-  public void setConfig(ConfigurationSection config) {
-    minFallHeight = config.getInt("min-fall-height", 100);
-  }
+  private final Supplier<Integer> MIN_FALL_HEIGHT = useConfig("min-fall-height", 100);
+  private final Map<UUID, Vector> placedWater = useState(Scope.LIFE);
+  private TrackerMatchModule tracker;
 
   @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
   public void onMatchLoad(MatchAfterLoadEvent event) {
@@ -82,7 +75,7 @@ public class WaterDropperObjective extends ObjectiveTracker {
       GenericFallInfo info = (GenericFallInfo) damageInfo;
       double distance = Trackers.distanceFromRanged(info, event.getPlayer().getLocation());
 
-      if (!Double.isNaN(distance) && distance >= minFallHeight) {
+      if (!Double.isNaN(distance) && distance >= MIN_FALL_HEIGHT.get()) {
         reward(event.getPlayer());
       }
     }

--- a/src/main/java/tc/oc/bingo/objectives/WoolCollectorObjective.java
+++ b/src/main/java/tc/oc/bingo/objectives/WoolCollectorObjective.java
@@ -5,9 +5,9 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import org.bukkit.Material;
-import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -21,12 +21,7 @@ import org.jetbrains.annotations.Nullable;
 @Tracker("wool-collector")
 public class WoolCollectorObjective extends ObjectiveTracker.Stateful<Set<Integer>> {
 
-  private int minWoolCount = 5;
-
-  @Override
-  public void setConfig(ConfigurationSection config) {
-    minWoolCount = config.getInt("min-wool-count", 5);
-  }
+  private final Supplier<Integer> MIN_WOOL_COUNT = useConfig("min-wool-count", 8);
 
   @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
   public void onPlayerPickUpItem(final PlayerPickupItemEvent event) {
@@ -53,7 +48,7 @@ public class WoolCollectorObjective extends ObjectiveTracker.Stateful<Set<Intege
     Set<Integer> indexes = getObjectiveData(playerId);
     if (indexes.add(woolId)) {
       storeObjectiveData(playerId, indexes);
-      if (indexes.size() >= minWoolCount) {
+      if (indexes.size() >= MIN_WOOL_COUNT.get()) {
         reward(player);
       }
     }


### PR DESCRIPTION
Depends on #5 , that should be merged first

Adds the api proposed in, and therefore closes #4, where trackers can simply call an `useConfig` to get an automatically managed lifetime for a config.

Eg:
```java
public class YourObjective extends ObjectiveTracker {
  private final Supplier<Boolean> SOME_CONFIG = useConfig("some-config", false);

  @EventHandler
  public onSomeEvent(...) {
    if (SOME_CONFIG.get()) {
    ...    
    }
  }
}
```