### PR TITLE
feat: allow showing coordinates for objectives with hints

### DIFF
--- a/src/main/java/tc/oc/bingo/config/Config.java
+++ b/src/main/java/tc/oc/bingo/config/Config.java
@@ -16,6 +16,7 @@ public class Config {
   private int gridWidth;
   private int seasonId;
   private boolean advent;
+  private boolean showObjectiveCoords;
 
   // Rewards
   private int rewardSingle;
@@ -43,7 +44,7 @@ public class Config {
                             (String)
                                 Objects.requireNonNullElse(map.get("description"), map.get("slug")),
                             (int) map.get("idx"),
-                            10,
+                            (int) Objects.requireNonNullElse(map.get("hintLevel"), 10),
                             null,
                             null,
                             null,
@@ -72,7 +73,7 @@ public class Config {
     this.gridWidth = config.getInt("grid-width", 5);
 
     this.seasonId = config.getInt("season-id", 1);
-
+    this.showObjectiveCoords = config.getBoolean("show-objective-coords", true);
     this.advent = config.getBoolean("advent", false);
 
     this.rewardSingle = config.getInt("rewards.single", 100);

--- a/src/main/java/tc/oc/bingo/menu/BingoCardMenu.java
+++ b/src/main/java/tc/oc/bingo/menu/BingoCardMenu.java
@@ -29,6 +29,7 @@ import org.bukkit.inventory.meta.ItemMeta;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import tc.oc.bingo.Bingo;
+import tc.oc.bingo.config.Config;
 import tc.oc.bingo.database.BingoCard;
 import tc.oc.bingo.database.BingoPlayerCard;
 import tc.oc.bingo.database.ObjectiveItem;
@@ -168,10 +169,11 @@ public class BingoCardMenu implements InventoryProvider {
       addSpaced(loreList, GRAY + "Discovered by: " + by);
     }
 
+    boolean showCoordinate = hints.unlocked <= 0 || Config.get().isShowObjectiveCoords();
+
     String name =
-        hints.unlocked > 0
-            ? objective.getName()
-            : MAGIC + "NiceTry" + AQUA + " (" + objective.getGridPosition() + ")";
+        (hints.unlocked > 0 ? objective.getName() : MAGIC + "NiceTry")
+            + (showCoordinate ? AQUA + " (" + objective.getGridPosition() + ")" : "");
 
     return createIconItem(
         objective.getIndex(),

--- a/src/main/java/tc/oc/bingo/util/Messages.java
+++ b/src/main/java/tc/oc/bingo/util/Messages.java
@@ -14,6 +14,7 @@ import net.kyori.adventure.text.format.TextDecoration;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.Nullable;
 import tc.oc.bingo.card.RewardManager;
+import tc.oc.bingo.config.Config;
 import tc.oc.bingo.database.ObjectiveItem;
 import tc.oc.pgm.util.named.NameStyle;
 import tc.oc.pgm.util.player.PlayerComponent;
@@ -119,19 +120,23 @@ public class Messages {
   }
 
   public static Component goalCompleted(Component completer, ObjectiveItem objectiveItem) {
+    boolean showCoordinate =
+        !objectiveItem.shouldShowName() || Config.get().isShowObjectiveCoords();
+
     TextComponent objectiveName =
         objectiveItem.shouldShowName()
             ? text(objectiveItem.getName(), NamedTextColor.AQUA)
-            : text("")
-                .append(text("NiceTry", NamedTextColor.AQUA, TextDecoration.OBFUSCATED))
-                .append(text(" (" + objectiveItem.getGridPosition() + ")", NamedTextColor.AQUA));
+            : text("").append(text("NiceTry", NamedTextColor.AQUA, TextDecoration.OBFUSCATED));
 
     return Messages.getBingoPrefix()
         .append(completer)
         .append(text(" completed the goal", NamedTextColor.GRAY))
         .append(space())
         .append(
-            objectiveName
+            (showCoordinate
+                    ? objectiveName.append(
+                        text(" (" + objectiveItem.getGridPosition() + ")", NamedTextColor.AQUA))
+                    : objectiveName)
                 .hoverEvent(
                     showText(
                         text("Click to see your progress using ", NamedTextColor.GRAY)

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -2,6 +2,7 @@
 grid-width: 5
 season-id: 1
 advent: false
+show-objective-coords: true
 
 # Rewards based on unlock type
 rewards:


### PR DESCRIPTION
Adds a config option to allow showing coordinates for objectives that already have some hints revealed. This applies to both the bingo card, and completion messages.

The objective coordinate will always be shown when no hint has been revealed yet.

![A screenshot of a "Heavy Metal" task in the bingo card located at A2, displayed as "Heavy Metal (A2)"](https://github.com/user-attachments/assets/fda80447-f49d-4e0f-9724-9099bcc8d457)

![A screenshot of an unknown task at A1 next to a "Heavy Metal" task (displayed as "Heavy Metal (A2)") being completed](https://github.com/user-attachments/assets/ec5834b2-52c6-41a7-9cba-7098fad5f22a)


Fixes https://github.com/OvercastCommunity/Bingo/issues/10