### PR TITLE
fix: don't display remaining time in 24-48h intervals as HH:MM

### DIFF
--- a/src/main/java/tc/oc/bingo/util/Messages.java
+++ b/src/main/java/tc/oc/bingo/util/Messages.java
@@ -62,7 +62,7 @@ public class Messages {
       return days + " days" + spacedTimeString(hours % 24, "hour", "hours");
     }
 
-    // Cutoff after 6 hours when only hours are shown
+    // Cutoff after 12 hours when only hours are shown
     if (hours >= 12) {
       return hours + " hours";
     }

--- a/src/main/java/tc/oc/bingo/util/Messages.java
+++ b/src/main/java/tc/oc/bingo/util/Messages.java
@@ -52,18 +52,18 @@ public class Messages {
     long hours = remaining.toHours();
     long minutes = remaining.toMinutes() % 60;
 
-    // When over 6 days just include days
-    if (days > 6) {
+    // When over 7 days just include days
+    if (days >= 7) {
       return days + " days";
     }
 
-    // If over a day include the days and hours
-    if (days > 1) {
+    // If over 2 days include the days and hours
+    if (days >= 2) {
       return days + " days" + spacedTimeString(hours % 24, "hour", "hours");
     }
 
     // Cutoff after 6 hours when only hours are shown
-    if (hours >= 6 && hours < 24) {
+    if (hours >= 6) {
       return hours + " hours";
     }
 

--- a/src/main/java/tc/oc/bingo/util/Messages.java
+++ b/src/main/java/tc/oc/bingo/util/Messages.java
@@ -63,7 +63,7 @@ public class Messages {
     }
 
     // Cutoff after 6 hours when only hours are shown
-    if (hours >= 6) {
+    if (hours >= 12) {
       return hours + " hours";
     }
 


### PR DESCRIPTION
Fixes an inconsistency where the remaining time to unlock a hint/objective within a 24-48h interval would show up with a precise hours + minutes duration.

Additionally, the `days > 6` condition has been changed to `days >= 7` to better align with human understanding of time (both comparisons are equivalent).